### PR TITLE
feat: as foundry now supports .env let's copy .env.example to .env [RFC]

### DIFF
--- a/.github/workflows/foundry-test.yml
+++ b/.github/workflows/foundry-test.yml
@@ -18,6 +18,9 @@ jobs:
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: nightly
+          
+      - name: Copy .env
+        run: cp .env.example .env
 
       - name: Run Forge build
         run: |


### PR DESCRIPTION
For this to work the assumption is that .env-contains reasonable defaults