### PR TITLE
fix: replace outdates path in report-generator step

### DIFF
--- a/.github/actions/foundry-test/action.yml
+++ b/.github/actions/foundry-test/action.yml
@@ -35,11 +35,11 @@ runs:
     - name: Generate Report
       shell: bash
       run: |
-        if [ -f /tmp/sizes-report/sizes.json ]; then
+        if [ -f /tmp/sizes.json ]; then
           mv /tmp/sizes.json /tmp/sizes.base.json
         fi
-        forge build --sizes --json > /tmp/sizes.json
-        ## if the base file doesn't exist, we compare against the current file
+        forge build --sizes --json > /tmp/sizes.json || echo "Sizes report failed"
+        ## if the base file doesn't exist, we compare against itself
         if [ ! -f /tmp/sizes.base.json ]; then
           cp /tmp/sizes.json /tmp/sizes.base.json
         fi


### PR DESCRIPTION
forgot to switch this, causing the sizes.base.json not to exist.