### PR TITLE
fix: Simplify release job conditions in workflow

### DIFF
--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -14,10 +14,6 @@ on:
 
 jobs:
   release:
-    if: |
-      github.event_name == 'push' &&
-      github.ref == format('refs/heads/{0}', github.event.repository.default_branch) &&
-      contains(github.event.head_commit.message, 'chore(main): release')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
So that users of the workflow can decide if they'd like to add further constraints. I think putting assumptions on the commit message is a bit over the top.